### PR TITLE
Fix duplicated heading and description for Authorization Workshop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,50 @@
 # .NET Presentations
 
 ## Decks
-### [What is .NET?](https://github.com/dotnet-presentations/home/tree/master/.NET%20Intro) 
-Level 100 Beginner 45min presentation on what .NET is and how to get started! 
+
+### [What is .NET?](https://github.com/dotnet-presentations/home/tree/master/.NET%20Intro)
+
+Level 100 Beginner 45min presentation on what .NET is and how to get started!
 
 ### [ASP.NET Core - Security and Identity](https://github.com/dotnet-presentations/home/tree/master/Security/ASP.NET%20Core%202.0)
+
 Overview of Security and Identity in ASP.NET Core 2.0, including Authorization Policies, Cookie Auth, and TOTP. Demos included.
 
 ## Workshops
+
 ### [ASP.NET Core For Beginners](https://github.com/dotnet-presentations/aspnetcore-for-beginners)
+
 Are you completely new to .NET? No problem! Here's a half day workshop for developers who have no experience with .NET Core or ASP.NET ASP.NET. We'll start with the basics and build up to a movie database website with search.
 
 ### [ASP.NET Core App Workshop](https://github.com/dotnet-presentations/aspnetcore-app-workshop)
+
 In this workshop, you'll learn by building a full-featured ASP.NET Core application from scratch. We'll start from File/ New and build up to an API back-end application, a web front-end application, and a common library for shared data transfer objects using .NET Standard.
 
 ### [.NET Core Workshop](https://github.com/dotnet-presentations/dotnetcore-workshop)
-Are you ready to get started with .NET Core? This one day workshop covers the basics, then digs into web development with ASP.NET Core, 
+
+Are you ready to get started with .NET Core? This one day workshop covers the basics, then digs into web development with ASP.NET Core,
 .NET Standard, porting from .NET Framework, and containers.
 
 ### [ASP.NET Core Authorization Workshop](https://github.com/blowdart/AspNetAuthorizationWorkshop)
+
 A workshop for moving through the various new pieces in ASP.NET Core Authorization.
 
-### [ASP.NET Core Authentication Workshop](https://github.com/blowdart/AspNetAuthenticationWorkshop)
-A workshop for moving through the various new pieces in ASP.NET Core Authentication.
-
 ### [ASP.NET Core Overview Workshop](https://github.com/dotnet-presentations/aspnetcore-workshop)
+
 This ASP.NET Core workshop is broken down by topics: middleware, front-end, etc.
 
 ## Community E-Books and Tutorials
-### [Build an Airport Explorer with ASP.NET Core](https://www.jerriepelser.com/books/airport-explorer) 
+
+### [Build an Airport Explorer with ASP.NET Core](https://www.jerriepelser.com/books/airport-explorer)
+
 This free e-book guides you through creating a really cool application using ASP.NET Core Razor Pages, AJAX, 3rd party APIs, mapping, data integration with CSV source data, and more.
 
-### [The Little ASP.NET Core Book](https://www.recaffeinate.co/book/) 
+### [The Little ASP.NET Core Book](https://www.recaffeinate.co/book/)
+
 You don’t need to know anything about web programing or ASP.NET Core to get started! The Little ASP.NET Core Book is structured as a tutorial. You’ll build an app from start to finish and learn:
- * How to build an application with the ASP.NET Core framework
- * The basics of the MVC (Model-View-Controller) pattern
- * How to read and write data to a database
- * How to add login, registration, and security
- * How to deploy the app to the web
+
+- How to build an application with the ASP.NET Core framework
+- The basics of the MVC (Model-View-Controller) pattern
+- How to read and write data to a database
+- How to add login, registration, and security
+- How to deploy the app to the web


### PR DESCRIPTION
Looks like my VS Code auto-formatted the markdown file and added some whitespace. Let me know if you want me to revert the whitespace or not.